### PR TITLE
Support for lts-18.0

### DIFF
--- a/pg-schema/pg-schema.cabal
+++ b/pg-schema/pg-schema.cabal
@@ -98,6 +98,7 @@ library
     , RecordWildCards
     , ScopedTypeVariables
     , StandaloneDeriving
+    , StandaloneKindSignatures
     , TemplateHaskell
     , TypeOperators
     , TupleSections

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,3 +12,5 @@ packages:
 # extra-deps:
 # - git: https://github.com/odr/singletons.git
 #   commit: ad8a595ab1811d0e7f17d6829b7edf29a7eaa96a
+nix:
+  packages: [zip postgresql]


### PR DESCRIPTION
1. Added `-XStandaloneKindSignatures`  otherwise build fails under lts-18.0 with following error
```
pg-schema            > /home/vlad/job/pg-schema/pg-schema/src/Database/Schema/Def.hs:19:1: error:
pg-schema            >     Illegal standalone kind signature
pg-schema            >       Did you mean to enable StandaloneKindSignatures?
pg-schema            >    |
pg-schema            > 19 | singletons [d|
```
2. This makes possible to build under nixos:
```yaml
nix:
  packages: [zip postgresql]
```